### PR TITLE
Initial addition of support for Pipfiles (Pipenv)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 It lets you view the latest version of each package of your dependency.
 
-**Currently supports `package.json`, `Cargo.toml` and `requirements.txt`**
+**Currently supports `package.json`, `Cargo.toml`, `requirements.txt` and `Pipfile`**
 
-| ![](https://i.imgur.com/YTaFHzs.png) | ![](https://i.imgur.com/HqgozdY.png) | ![](https://i.imgur.com/evCwnHZ.png) |
-| :----------------------------------: | :----------------------------------: | :----------------------------------: |
-|              Cargo.toml              |             package.json             |           requirements.txt           |
+| ![](https://i.imgur.com/YTaFHzs.png) | ![](https://i.imgur.com/HqgozdY.png) | ![](https://i.imgur.com/evCwnHZ.png) | ![]() |
+| :----------------------------------: | :----------------------------------: | :----------------------------------: | :----------------------------------: |
+|              Cargo.toml              |             package.json             |           requirements.txt           |               Pipfile                |
 
 Default colors:
 

--- a/examples/Pipfile
+++ b/examples/Pipfile
@@ -1,0 +1,17 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+"flake8" = ">=3.5.0"
+pylint = ">=2.1.1"
+
+[packages]
+guessit = ">=3.0.0"
+tvdb-api = ">=2.0"
+imdbpy = ">=6.6"
+musicbrainzngs = ">=0.6"
+
+[requires]
+python_version = "3.6"

--- a/rplugin/node/vim-package-info/diff.js
+++ b/rplugin/node/vim-package-info/diff.js
@@ -1,8 +1,8 @@
 var semverUtils = require("semver-utils");
 
 function colorizeDiff(current, latest, hl) {
-  if (current && (current[0] === "^" || current[0] === "~"))
-    current = current.substr(1);
+  // parse current version number (e.g. ">=1.0", "^1.0", "~1.0" -> "1.0")
+  current = current.match(/(\d+\.)?(\d+\.)?(\*|\d+)/)[0];
 
   // stupid semver issue
   for (let i = current.split(".").length; i < 3; i++) current = current + ".0";

--- a/rplugin/node/vim-package-info/index.js
+++ b/rplugin/node/vim-package-info/index.js
@@ -52,7 +52,7 @@ async function fetchAll(nvim) {
 
   const filePath = await nvim.nvim.commandOutput("echo expand('%')");
   const confType = path.basename(filePath);
-  const fileType = confType.split(".")[confType.split(".").length - 1];
+  const fileType = await nvim.nvim.commandOutput("echo &filetype");
 
   // done here so as to check if the file is parseable
   let data = parser.getParsedFile(bf.join("\n"), fileType);
@@ -118,7 +118,7 @@ module.exports = nvim => {
 
   ["BufEnter", "InsertLeave", "TextChanged"].forEach(e => {
     nvim.registerAutocmd(e, async () => await fetchAll(nvim), {
-      pattern: "*/package.json,*/Cargo.toml,*/requirements.txt"
+      pattern: "*/package.json,*/Cargo.toml,*/requirements.txt,*/Pipfile"
     });
   });
 };

--- a/rplugin/node/vim-package-info/parser.js
+++ b/rplugin/node/vim-package-info/parser.js
@@ -6,11 +6,13 @@ const depMarkers = {
   "package.json": [[/["|'](dependencies)["|']/, /\}/], [/["|'](devDependencies)["|']/, /\}/]],
   "Cargo.toml": [[/\[(.*dependencies)\]/, /^ *\[.*\].*/]],
   "requirements.txt": null,
+  "Pipfile": [[/\[(packages)\]/, /^ *\[.*\].*/], [/\[(dev-packages)\]/, /^ *\[.*\].*/]]
 };
 const nameParserRegex = {
   "package.json": /['|"](.*)['|"] *:/,
   "Cargo.toml": /([a-zA-Z0-9\-_]*) *=.*/,
   "requirements.txt": /^ *([a-zA-Z_]+[a-zA-Z0-9\-_]*).*/,
+  "Pipfile": /"?([a-zA-Z0-9\-_]*)"? *=.*/
 };
 
 function isStart(line, confType) {
@@ -57,7 +59,7 @@ function getParsedFile(file, fileType) {
   let data;
   if (fileType === "toml") data = toml.parse(file);
   else if (fileType === "json") data = JSON.parse(file);
-  else if (fileType === "txt") data = file;
+  else if (fileType === "text") data = file;
   return data;
 }
 

--- a/rplugin/node/vim-package-info/utils.js
+++ b/rplugin/node/vim-package-info/utils.js
@@ -7,6 +7,7 @@ if (!("vimnpmcache" in global)) {
     "package.json": {},
     "Cargo.toml": {},
     "requirements.txt": {},
+    "Pipfile": {}
   };
 }
 
@@ -17,6 +18,7 @@ function getUrl(package, confType) {
     case "Cargo.toml":
       return `https://crates.io/api/v1/crates/${package}`;
     case "requirements.txt":
+    case "Pipfile":
       return `https://pypi.org/pypi/${package}/json`;
     default:
       return false;
@@ -37,6 +39,7 @@ function getLatestVersion(data, confType) {
       }
       break;
     case "requirements.txt":
+    case "Pipfile":
       if ("info" in data) {
         return data["info"].version;
       }

--- a/test/options.js
+++ b/test/options.js
@@ -99,10 +99,47 @@ const tests = [
           },
           {
             line: "six==1.12.0 \\",
-            depSelector: 'null',
+            depSelector: "null",
             output: {
               name: "six",
               version: "1.12.0",
+            },
+          },
+        ],
+      },
+    },
+  },
+
+  {
+    name: "Pipfile (Python)",
+    file: "Pipfile",
+    type: "toml",
+    tests: {
+      url: {
+        package: "pylint",
+        url: "https://pypi.org/pypi/pylint/json",
+      },
+      dep_lines: {
+        packages: [10, 16],
+        "dev-packages": [6, 10],
+      },
+      version_extraction: {
+        data: { packages: { "tvdb-api": "2.0" }, "dev-packages": { pylint: "2.1.1" } },
+        checks: [
+          {
+            line: 'tvdb-api = ">=2.0"',
+            depSelector: "packages",
+            output: {
+              name: "tvdb-api",
+              version: "2.0",
+            },
+          },
+          {
+            line: 'pylint = ">=2.1.1"',
+            depSelector: "dev-packages",
+            output: {
+              name: "pylint",
+              version: "2.1.1",
             },
           },
         ],


### PR DESCRIPTION
Initial addition of support for Pipfiles (Pipenv)

## Description

Modified parser to allow the displaying of module version info for Pipfiles (Pipenv). I have updated the README.md, however, I have omitted the addition of an screenshot so that @meain can add one (keeping the colour scheme uniform); I also don't have an Imgur account.

## Testing

Where I have modified anything that will effect the other supported filetypes, I have check to ensure that they still function as expected.

I have also added an example Pipfile which can be viewed [here](https://github.com/jamesl33/vim-package-info/blob/pipfile-support/examples/Pipfile).
