### PR TITLE
Generalize the key off the name of the file, and add pyproject.toml support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,19 @@
 
 It lets you view the latest version of each package of your dependency.
 
-**Currently supports `package.json`, `Cargo.toml`, `requirements.txt` and `Pipfile`**
+**Currently supports:**
+ * javascript:
+   * `package.json`
+ * rust:
+   * `Cargo.toml`
+ * python:
+   * `requirements.txt`
+   * `Pipfile`
+   * `pyproject.toml`
 
-| ![](https://i.imgur.com/YTaFHzs.png) | ![](https://i.imgur.com/HqgozdY.png) | ![](https://i.imgur.com/evCwnHZ.png) | ![](https://i.imgur.com/PzX89H1.png) |
-| :----------------------------------: | :----------------------------------: | :----------------------------------: | :----------------------------------: |
-|              Cargo.toml              |             package.json             |           requirements.txt           |               Pipfile                |
+| ![](https://i.imgur.com/YTaFHzs.png) | ![](https://i.imgur.com/HqgozdY.png) | ![](https://i.imgur.com/evCwnHZ.png) | ![](https://i.imgur.com/PzX89H1.png) | ![](https://i.imgur.com/s6Cu8oZ.png) |
+| :----------------------------------: | :----------------------------------: | :----------------------------------: | :----------------------------------: | :----------------------------------: |
+|              Cargo.toml              |             package.json             |           requirements.txt           |               Pipfile                |             pyproject.toml           |
 
 Default colors:
 

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "example"
+version = "0.0.1"
+
+[tool.poetry.dependencies]
+python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
+
+guessit = ">=3.0.0"
+tvdb-api = ">=2.0"
+imdbpy = ">=6.6"
+musicbrainzngs = ">=0.6"
+
+[tool.poetry.dev-dependencies]
+"flake8" = ">=3.5.0"
+pylint = {version = ">=2.1.1"}
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/rplugin/node/vim-package-info/index.js
+++ b/rplugin/node/vim-package-info/index.js
@@ -51,8 +51,10 @@ async function fetchAll(nvim) {
   // if (bf.join("\n") === global.previousBuffer) return;
 
   const filePath = await nvim.nvim.commandOutput("echo expand('%')");
-  const confType = path.basename(filePath);
   const fileType = await nvim.nvim.commandOutput("echo &filetype");
+
+  const filename = path.basename(filePath);
+  const confType = utils.determineFileKind(filename);
 
   // done here so as to check if the file is parseable
   let data = parser.getParsedFile(bf.join("\n"), fileType);
@@ -118,7 +120,7 @@ module.exports = nvim => {
 
   ["BufEnter", "InsertLeave", "TextChanged"].forEach(e => {
     nvim.registerAutocmd(e, async () => await fetchAll(nvim), {
-      pattern: "*/package.json,*/Cargo.toml,*/requirements.txt,*/Pipfile"
+      pattern: "*/package.json,*/Cargo.toml,*/*requirements.txt,*/Pipfile,*/pyproject.toml"
     });
   });
 };

--- a/rplugin/node/vim-package-info/utils.js
+++ b/rplugin/node/vim-package-info/utils.js
@@ -4,21 +4,41 @@ if (!("vimnpmcache" in global)) {
   // you might think that we do not have to have two diffent objects
   // but there might be a single project with both package.json and Cargo.toml
   global.vimnpmcache = {
-    "package.json": {},
-    "Cargo.toml": {},
-    "requirements.txt": {},
-    "Pipfile": {}
+    "javascript": {},
+    "rust": {},
+    "python:requirements": {},
+    "python:pipfile": {},
+    "python:pyproject": {}
   };
+}
+
+function determineFileKind(filename) {
+  if (filename.match(/^.*?requirements.txt$/)) {
+    return "python:requirements";
+  }
+  if (filename.match(/^pyproject.toml$/)) {
+    return "python:pyproject";
+  }
+  if (filename.match(/^Pipfile/)) {
+    return "python:pipfile";
+  }
+  if (filename.match(/^Cargo.toml$/)) {
+    return "rust";
+  }
+  if (filename.match(/^package.json$/)) {
+    return "javascript";
+  }
 }
 
 function getUrl(package, confType) {
   switch (confType) {
-    case "package.json":
+    case "javascript":
       return `https://registry.npmjs.org/${package}`;
-    case "Cargo.toml":
+    case "rust":
       return `https://crates.io/api/v1/crates/${package}`;
-    case "requirements.txt":
-    case "Pipfile":
+    case "python:requirements":
+    case "python:pipfile":
+    case "python:pyproject":
       return `https://pypi.org/pypi/${package}/json`;
     default:
       return false;
@@ -28,18 +48,19 @@ function getUrl(package, confType) {
 function getLatestVersion(data, confType) {
   data = JSON.parse(data);
   switch (confType) {
-    case "package.json":
+    case "javascript":
       if ("dist-tags" in data) {
         return data["dist-tags"].latest;
       }
       break;
-    case "Cargo.toml":
+    case "rust":
       if ("crate" in data) {
         return data["crate"].max_version;
       }
       break;
-    case "requirements.txt":
-    case "Pipfile":
+    case "python:requirements":
+    case "python:pipfile":
+    case "python:pyproject":
       if ("info" in data) {
         return data["info"].version;
       }
@@ -80,4 +101,4 @@ function load(package, confType) {
   return false;
 }
 
-module.exports = { fetchInfo, getLatestVersion, save, load, getUrl };
+module.exports = { fetchInfo, getLatestVersion, save, load, getUrl, determineFileKind };

--- a/test/file_test.js
+++ b/test/file_test.js
@@ -8,16 +8,18 @@ const tests = require("./options").tests;
 tests.forEach(test => {
   const file = String(fs.readFileSync(`examples/${test.file}`));
 
+  const fileKind = utils.determineFileKind(test.file);
+
   describe(test.name, function() {
     describe("utils", function() {
       it("return proper url", function() {
-        assert.equal(utils.getUrl(test.tests.url.package, test.file), test.tests.url.url);
+        assert.equal(utils.getUrl(test.tests.url.package, fileKind), test.tests.url.url);
       });
     });
 
     describe("parser", function() {
       it("gets proper dep lines", function() {
-        assert.deepEqual(parser.getDepLines(file.split("\n"), test.file), test.tests.dep_lines);
+        assert.deepEqual(parser.getDepLines(file.split("\n"), fileKind), test.tests.dep_lines);
       });
 
       it("gets proper version extracted", function() {
@@ -25,7 +27,7 @@ tests.forEach(test => {
           assert.deepEqual(
             parser.getPackageInfo(
               line.line,
-              test.file,
+              fileKind,
               test.tests.version_extraction.data,
               line.depSelector
             ),

--- a/test/options.js
+++ b/test/options.js
@@ -154,6 +154,43 @@ const tests = [
       },
     },
   },
+
+  {
+    name: "pyproject (Python)",
+    file: "pyproject.toml",
+    type: "toml",
+    tests: {
+      url: {
+        package: "pylint",
+        url: "https://pypi.org/pypi/pylint/json",
+      },
+      dep_lines: {
+        "tool.poetry.dependencies": [5, 13],
+        "tool.poetry.dev-dependencies": [13, 17],
+      },
+      version_extraction: {
+        data: { packages: { "tvdb-api": "2.0" }, "dev-packages": { pylint: "2.1.1" } },
+        checks: [
+          {
+            line: 'tvdb-api = ">=2.0"',
+            depSelector: "packages",
+            output: {
+              name: "tvdb-api",
+              version: "2.0",
+            },
+          },
+          {
+            line: 'pylint = ">=2.1.1"',
+            depSelector: "dev-packages",
+            output: {
+              name: "pylint",
+              version: "2.1.1",
+            },
+          },
+        ],
+      },
+    },
+  },
 ];
 
 module.exports = { tests };


### PR DESCRIPTION
The way we store our requirements files are often stored are `deps/requirements.txt` and `deps/dev-requirements.txt`, `testing-`, etc. This didn't jive particularly well with the direct mapping from filename to the general handling of that file-kind. So I first created a slightly more generic mapping off which the rest of the code could pivot, but which didn't directly map to the exact file name.

Also I added pyproject.toml support (specifically for `poetry`, but doesn't have anything specific to poetry other than the assumption of part of the name of the key under which deps exist).

(ps its somewhat amusing that I created this PR, and the other pending PR right now is for Pipfile. it speaks to the craziness of python's packaging standards or lack thereof)