### PR TITLE
add additional package.json dependency groups

### DIFF
--- a/rplugin/node/vim-package-info/parsers/package-json.js
+++ b/rplugin/node/vim-package-info/parsers/package-json.js
@@ -7,8 +7,8 @@ const render = require("../render");
 const rutils = require("../render_utils");
 
 const LANGUAGE = "javascript";
-const depGroups = ["dependencies", "devDependencies"];
-const markers = [[/["|'](dependencies)["|']/, /\}/], [/["|'](devDependencies)["|']/, /\}/]];
+const depGroups = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
+const markers = depGroups.map((prop) => [new RegExp(`["|'](${prop})["|']`), /\}/]);
 const nameRegex = /['|"](.*)['|"] *:/;
 
 class PackageJson {


### PR DESCRIPTION
Now package.json parser takes into account this dependency groups:

- peerDependencies
- optionalDependencies

With this new groups we fully cover all dependency groups defined in the
standard (https://docs.npmjs.com/cli/v6/configuring-npm/package-json).