### PR TITLE
feat: Show version hint even if dependency is duplicated

### DIFF
--- a/rplugin/node/vim-package-info/parsers/cargo.js
+++ b/rplugin/node/vim-package-info/parsers/cargo.js
@@ -61,10 +61,11 @@ class CargoParser {
 
     const info = global.store.get(LANGUAGE, dep);
 
-    const lineNumber = rutils.getDepLine(bufferLines, markers, nameRegex, dep, true);
+    const lineNumbers = rutils.getDepLines(bufferLines, markers, nameRegex, dep, true);
     const isVulnerable = "vulnerabilities" in info && info.vulnerabilities.length > 0;
-    if (lineNumber)
-      await render.drawOne(handle, lineNumber, info.current_version, info.latest, isVulnerable);
+    for (let ln of lineNumbers) {
+      await render.drawOne(handle, ln, info.current_version, info.latest, isVulnerable);
+    }
   }
 }
 

--- a/rplugin/node/vim-package-info/parsers/package-json.js
+++ b/rplugin/node/vim-package-info/parsers/package-json.js
@@ -91,10 +91,11 @@ class PackageJson {
 
     const info = global.store.get(LANGUAGE, dep);
 
-    const lineNumber = rutils.getDepLine(bufferLines, markers, nameRegex, dep);
+    const lineNumbers = rutils.getDepLines(bufferLines, markers, nameRegex, dep);
     const isVulnerable = "vulnerabilities" in info && info.vulnerabilities.length > 0;
-    if (lineNumber)
-      await render.drawOne(handle, lineNumber, info.current_version, info.latest, isVulnerable);
+    for (let ln of lineNumbers) {
+      await render.drawOne(handle, ln, info.current_version, info.latest, isVulnerable);
+    }
   }
 }
 

--- a/rplugin/node/vim-package-info/parsers/pipfile.js
+++ b/rplugin/node/vim-package-info/parsers/pipfile.js
@@ -68,10 +68,11 @@ class PipfileParser {
     const info = global.store.get(LANGUAGE, dep);
 
     // TODO: switch from latest_version to latest_semver satisfied version
-    const lineNumber = rutils.getDepLine(bufferLines, markers, nameRegex, dep, true);
+    const lineNumbers = rutils.getDepLines(bufferLines, markers, nameRegex, dep, true);
     const isVulnerable = "vulnerabilities" in info && info.vulnerabilities.length > 0;
-    if (lineNumber)
-      await render.drawOne(handle, lineNumber, info.current_version, info.latest, isVulnerable);
+    for (let ln of lineNumbers) {
+      await render.drawOne(handle, ln, info.current_version, info.latest, isVulnerable);
+    }
   }
 }
 

--- a/rplugin/node/vim-package-info/parsers/pyproject-toml.js
+++ b/rplugin/node/vim-package-info/parsers/pyproject-toml.js
@@ -62,11 +62,12 @@ class PyprojectToml {
     const bufferLines = await buffer.getLines();
 
     const info = global.store.get(LANGUAGE, dep);
-    const lineNumber = rutils.getDepLine(bufferLines, markers, nameRegex, dep, true);
+    const lineNumbers = rutils.getDepLines(bufferLines, markers, nameRegex, dep, true);
     // TODO: switch from latest_version to latest_semver satisfied version
     const isVulnerable = "vulnerabilities" in info && info.vulnerabilities.length > 0;
-    if (lineNumber)
-      await render.drawOne(handle, lineNumber, info.current_version, info.latest, isVulnerable);
+    for (let ln of lineNumbers) {
+      await render.drawOne(handle, ln, info.current_version, info.latest, isVulnerable);
+    }
   }
 }
 

--- a/rplugin/node/vim-package-info/parsers/requirements-txt.js
+++ b/rplugin/node/vim-package-info/parsers/requirements-txt.js
@@ -59,10 +59,11 @@ class RequirementsTxt {
     const info = global.store.get(LANGUAGE, dep);
 
     // TODO: switch from latest_version to latest_semver satisfied version
-    const lineNumber = rutils.getDepLine(bufferLines, markers, nameRegex, dep, true);
+    const lineNumbers = rutils.getDepLines(bufferLines, markers, nameRegex, dep, true);
     const isVulnerable = "vulnerabilities" in info && info.vulnerabilities.length > 0;
-    if (lineNumber)
-      await render.drawOne(handle, lineNumber, info.current_version, info.latest, isVulnerable);
+    for (let ln of lineNumbers) {
+      await render.drawOne(handle, ln, info.current_version, info.latest, isVulnerable);
+    }
   }
 }
 

--- a/rplugin/node/vim-package-info/render_utils.js
+++ b/rplugin/node/vim-package-info/render_utils.js
@@ -14,9 +14,10 @@ function isStart(line, depMarkers) {
   return false;
 }
 
-function getDepLine(lines, depMarkers, nameRegex, name, end_maybe_start_of_next = false) {
+function getDepLines(lines, depMarkers, nameRegex, name, end_maybe_start_of_next = false) {
   let start = depMarkers === null ? true : false;
   let end = false;
+  let depLines = [];
   for (let i = 0; i < lines.length; i++) {
     if (start) {
       if (end && end !== null && end.test(lines[i])) {
@@ -33,7 +34,7 @@ function getDepLine(lines, depMarkers, nameRegex, name, end_maybe_start_of_next 
         vals[1] !== null &&
         vals[1].trim() === name.trim()
       ) {
-        return i;
+        depLines.push(i);
       }
       //eslint-disable-next-line
     } else if (!!isStart(lines[i], depMarkers)) {
@@ -41,7 +42,7 @@ function getDepLine(lines, depMarkers, nameRegex, name, end_maybe_start_of_next 
       end = isStart(lines[i], depMarkers).end;
     }
   }
-  return null;
+  return depLines;
 }
 
 function format(current, prefix, hl, latest, vulnerable = false) {
@@ -56,4 +57,4 @@ function format(current, prefix, hl, latest, vulnerable = false) {
   return lpf;
 }
 
-module.exports = { getDepLine, format };
+module.exports = { getDepLines, format };


### PR DESCRIPTION
Closes #34 

> but wanted to post first in case I forget or get distracted.

*glances as calendar* Well that was one hell of a distraction.

This approach seems to work well with Node / `package.json` files, but unsure if it's even applicable to some of these other environments; not a regular user of them, sorry! I switched over all to use this alteration but certainly can revert if there are concerns.

---

To give a more illustrative example than the linked issue, here's the before and after from one of my projects:

Before             |  After
:-------------------------:|:-------------------------:
![Before this change](https://user-images.githubusercontent.com/33403762/206027075-ada38b5e-cbb6-4929-aa53-5de2d5235ead.png) | ![After this change](https://user-images.githubusercontent.com/33403762/206027131-84e9d0b3-8f36-4c0b-ae8a-1b1c80006418.png)

If I'm scanning my `"devDependencies"` in the "before", I'm missing a couple of entries. While this example has the annotation just a dozen or so lines away, in some packages it can be 50+.